### PR TITLE
chore: promote goodnode to version 0.0.1

### DIFF
--- a/config-root/namespaces/jx-production/goodnode/goodnode-goodnode-deploy.yaml
+++ b/config-root/namespaces/jx-production/goodnode/goodnode-goodnode-deploy.yaml
@@ -1,0 +1,60 @@
+# Source: goodnode/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: goodnode-goodnode
+  labels:
+    draft: draft-app
+    chart: "goodnode-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'goodnode'
+    wave.pusher.com/update-on-config-change: 'true'
+  namespace: jx-production
+spec:
+  selector:
+    matchLabels:
+      app: goodnode-goodnode
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: goodnode-goodnode
+    spec:
+      serviceAccountName: goodnode-goodnode
+      containers:
+        - name: goodnode
+          image: "gcr.io/jx3gke/goodnode:0.0.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.1
+          envFrom: null
+          ports:
+            - name: http
+              containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-production/goodnode/goodnode-goodnode-sa.yaml
+++ b/config-root/namespaces/jx-production/goodnode/goodnode-goodnode-sa.yaml
@@ -1,0 +1,10 @@
+# Source: goodnode/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: goodnode-goodnode
+  annotations:
+    meta.helm.sh/release-name: 'goodnode'
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-production/goodnode/goodnode-ingress.yaml
+++ b/config-root/namespaces/jx-production/goodnode/goodnode-ingress.yaml
@@ -1,0 +1,19 @@
+# Source: goodnode/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    meta.helm.sh/release-name: 'goodnode'
+  name: goodnode
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: goodnode
+              servicePort: 80
+      host: goodnode-jx-production.34.123.102.163.nip.io

--- a/config-root/namespaces/jx-production/goodnode/goodnode-svc.yaml
+++ b/config-root/namespaces/jx-production/goodnode/goodnode-svc.yaml
@@ -1,0 +1,20 @@
+# Source: goodnode/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: goodnode
+  labels:
+    chart: "goodnode-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'goodnode'
+  namespace: jx-production
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: goodnode-goodnode

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,12 @@
 	      <td><a href='https://github.com/jenkins-x-plugins/jx-verify'>source</a></td>
 	    </tr>
     <tr>
+	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> goodnode </a></td>
+	      <td>0.0.1</td>
+	      <td><a href='http://goodnode-jx-production.34.123.102.163.nip.io'>view</a></td>
+	      <td></td>
+	    </tr>
+    <tr>
 		      <td colspan='4'><h3>jx-staging</h3></td>
 		    </tr>
 	    <tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -15,6 +15,22 @@
     repositoryName: jx3
     repositoryUrl: https://storage.googleapis.com/jenkinsxio/charts
     resourcePath: config-root/namespaces/jx-production/jx-verify
+  - apiVersion: v1
+    appVersion: 0.0.1
+    applicationUrl: http://goodnode-jx-production.34.123.102.163.nip.io
+    description: A Helm chart for Kubernetes
+    firstDeployed: "2021-06-02T14:44:39Z"
+    icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
+    ingresses:
+    - name: goodnode
+      url: http://goodnode-jx-production.34.123.102.163.nip.io
+    lastDeployed: "2021-06-02T14:44:39Z"
+    logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=jx3gke&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Ftf-jx-skilled-piranha%2Fnamespace_name%2Fjx-production%2Fcontainer_name%2Fgoodnode&dateRangeUnbound=both
+    name: goodnode
+    repositoryName: dev
+    repositoryUrl: http://chartmuseum-jx.34.123.102.163.nip.io/
+    resourcePath: config-root/namespaces/jx-production/goodnode
+    version: 0.0.1
 - namespace: jx-staging
   path: helmfiles/jx-staging/helmfile.yaml
   releases:

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -6,11 +6,17 @@ environments:
 repositories:
 - name: jx3
   url: https://storage.googleapis.com/jenkinsxio/charts
+- name: dev
+  url: http://chartmuseum-jx.34.123.102.163.nip.io/
 releases:
 - chart: jx3/jx-verify
   name: jx-verify
   namespace: jx-production
   values:
   - jx-values.yaml
+- chart: dev/goodnode
+  version: 0.0.1
+  name: goodnode
+  namespace: jx-production
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -18,5 +18,7 @@ releases:
   version: 0.0.1
   name: goodnode
   namespace: jx-production
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote goodnode to version 0.0.1

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
